### PR TITLE
Populate changelog with previous releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,122 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.2.0
+
+([full changelog](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/compare/311f367...dd12b63))
+
+### Merged PRs
+
+- Update for JupyterLab 3.1.x, latest cookiecutter [#29](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/29) ([@parente](https://github.com/parente))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/graphs/contributors?from=2021-08-14&to=2021-12-12&type=c))
+
+[@parente](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-quickopen+involves%3Aparente+updated%3A2021-08-14..2021-12-12&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->
+
+## 1.1.0
+
+([full changelog](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/compare/65a2eac...311f367))
+
+### Merged PRs
+
+- Update for JupyterLab 3.1.x, latest cookiecutter [#29](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/29) ([@parente](https://github.com/parente))
+- Bump path-parse from 1.0.6 to 1.0.7 [#28](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/28) ([@dependabot](https://github.com/dependabot))
+- Bump tar from 6.0.5 to 6.1.5 [#27](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/27) ([@dependabot](https://github.com/dependabot))
+- Bump postcss from 7.0.35 to 7.0.36 [#26](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/26) ([@dependabot](https://github.com/dependabot))
+- Bump glob-parent from 5.1.1 to 5.1.2 [#25](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/25) ([@dependabot](https://github.com/dependabot))
+- Bump normalize-url from 4.5.0 to 4.5.1 [#24](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/24) ([@dependabot](https://github.com/dependabot))
+- Bump ws from 7.4.2 to 7.4.6 [#23](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/23) ([@dependabot](https://github.com/dependabot))
+- Bump browserslist from 4.16.0 to 4.16.6 [#22](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/22) ([@dependabot](https://github.com/dependabot))
+- Bump lodash from 4.17.20 to 4.17.21 [#21](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/21) ([@dependabot](https://github.com/dependabot))
+- Bump hosted-git-info from 2.8.8 to 2.8.9 [#20](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/20) ([@dependabot](https://github.com/dependabot))
+- Bump ssri from 8.0.0 to 8.0.1 [#19](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/19) ([@dependabot](https://github.com/dependabot))
+- Update binder to use jupyter_server [#18](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/18) ([@parente](https://github.com/parente))
+- Update extension to work with jupyterlab 3.0 [#17](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/17) ([@parente](https://github.com/parente))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/graphs/contributors?from=2020-12-31&to=2021-08-14&type=c))
+
+[@dependabot](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-quickopen+involves%3Adependabot+updated%3A2020-12-31..2021-08-14&type=Issues) | [@parente](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-quickopen+involves%3Aparente+updated%3A2020-12-31..2021-08-14&type=Issues)
+
+## 1.0.0
+
+([full changelog](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/compare/eb04bd1...65a2eac))
+
+### Merged PRs
+
+- Bump node-fetch from 2.6.0 to 2.6.1 [#15](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/15) ([@dependabot](https://github.com/dependabot))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/graphs/contributors?from=2020-03-20&to=2020-12-31&type=c))
+
+[@dependabot](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-quickopen+involves%3Adependabot+updated%3A2020-03-20..2020-12-31&type=Issues) | [@parente](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-quickopen+involves%3Aparente+updated%3A2020-03-20..2020-12-31&type=Issues)
+
+## 0.5.0
+
+([full changelog](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/compare/ca55830...eb04bd1))
+
+### Merged PRs
+
+- Jupyter 2.0.1 support [#13](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/13) ([@itaistopel](https://github.com/itaistopel))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/graphs/contributors?from=2020-03-07&to=2020-03-20&type=c))
+
+[@itaistopel](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-quickopen+involves%3Aitaistopel+updated%3A2020-03-07..2020-03-20&type=Issues) | [@parente](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-quickopen+involves%3Aparente+updated%3A2020-03-07..2020-03-20&type=Issues)
+
+## 0.4.1
+
+([full changelog](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/compare/6a1e07a...ca55830))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/graphs/contributors?from=2020-03-07&to=2020-03-07&type=c))
+
+
+
+## 0.4.0
+
+([full changelog](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/compare/f7c11a3...6a1e07a))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/graphs/contributors?from=2019-07-28&to=2020-03-07&type=c))
+
+
+
+## 0.3.0
+
+([full changelog](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/compare/e23408a...f7c11a3))
+
+### Merged PRs
+
+- Added relativeSearch functionality [#6](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/6) ([@StevenLaan](https://github.com/StevenLaan))
+- Support JupyterLab 1.0 [#5](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/5) ([@parente](https://github.com/parente))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/graphs/contributors?from=2019-06-30&to=2019-07-28&type=c))
+
+[@parente](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-quickopen+involves%3Aparente+updated%3A2019-06-30..2019-07-28&type=Issues) | [@StevenLaan](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-quickopen+involves%3AStevenLaan+updated%3A2019-06-30..2019-07-28&type=Issues)
+
+## 0.2.0
+
+([full changelog](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/compare/79a935a...e23408a))
+
+### Merged PRs
+
+- Add binder button and tutorial nb [#1](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/pull/1) ([@parente](https://github.com/parente))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/graphs/contributors?from=2018-12-04&to=2019-06-30&type=c))
+
+[@parente](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-quickopen+involves%3Aparente+updated%3A2018-12-04..2019-06-30&type=Issues)
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,8 +80,6 @@
 
 ([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/graphs/contributors?from=2020-03-07&to=2020-03-07&type=c))
 
-
-
 ## 0.4.0
 
 ([full changelog](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/compare/f7c11a3...6a1e07a))
@@ -89,8 +87,6 @@
 ### Contributors to this release
 
 ([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/graphs/contributors?from=2019-07-28&to=2020-03-07&type=c))
-
-
 
 ## 0.3.0
 
@@ -120,4 +116,3 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-quickopen/graphs/contributors?from=2018-12-04&to=2019-06-30&type=c))
 
 [@parente](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-quickopen+involves%3Aparente+updated%3A2018-12-04..2019-06-30&type=Issues)
-


### PR DESCRIPTION
Using `github-activity`: https://github-activity.readthedocs.io/en/latest/ with the following command:

```
github-activity jupyterlab-contrib/jupyterlab-quickopen --all --auth <GITHUB_TOKEN>
```