### PR TITLE
Add to the menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
         "@jupyterlab/docmanager": "^4.2.5",
         "@jupyterlab/filebrowser": "^4.2.5",
         "@jupyterlab/services": "^7.2.5",
-        "@jupyterlab/settingregistry": "^4.2.5"
+        "@jupyterlab/settingregistry": "^4.2.5",
+        "@jupyterlab/translation": "^4.2.5"
     },
     "devDependencies": {
         "@jupyterlab/builder": "^4.0.0",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -18,6 +18,23 @@
       "default": false
     }
   },
+  "jupyter.lab.menus": {
+    "main": [
+      {
+        "id": "jp-mainmenu-view",
+        "items": [
+          {
+            "command": "quickopen:activate",
+            "rank": 1
+          },
+          {
+            "type": "separator",
+            "rank": 1
+          }
+        ]
+      }
+    ]
+  },
   "jupyter.lab.shortcuts": [
     {
       "command": "quickopen:activate",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { IDocumentManager } from '@jupyterlab/docmanager';
 import { ServerConnection } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { FileBrowser, IDefaultFileBrowser } from '@jupyterlab/filebrowser';
+import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { CommandRegistry } from '@lumino/commands';
 import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 import { Message } from '@lumino/messaging';
@@ -128,20 +129,17 @@ class QuickOpenWidget extends CommandPalette {
 const extension: JupyterFrontEndPlugin<void> = {
   id: 'jupyterlab-quickopen:plugin',
   autoStart: true,
-  requires: [
-    ICommandPalette,
-    IDocumentManager,
-    ISettingRegistry,
-    IDefaultFileBrowser
-  ],
+  requires: [IDocumentManager, ISettingRegistry, IDefaultFileBrowser],
+  optional: [ICommandPalette, ITranslator],
   activate: async (
     app: JupyterFrontEnd,
-    palette: ICommandPalette,
     docManager: IDocumentManager,
     settingRegistry: ISettingRegistry,
-    defaultFileBrowser: IDefaultFileBrowser
+    defaultFileBrowser: IDefaultFileBrowser,
+    palette: ICommandPalette | null,
+    translator: ITranslator | null
   ) => {
-    console.log(`Activated extension: ${extension.id}`);
+    const trans = (translator ?? nullTranslator).load('jupyterlab-quickopen');
     const commands: CommandRegistry = new CommandRegistry();
     const settings: ISettingRegistry.ISettings = await settingRegistry.load(
       extension.id
@@ -173,12 +171,14 @@ const extension: JupyterFrontEndPlugin<void> = {
     // palette, assign a hotkey, etc.
     const command = 'quickopen:activate';
     app.commands.addCommand(command, {
-      label: 'Quick Open',
+      label: trans.__('Quick Open'),
       execute: () => {
         modalPalette.activate();
       }
     });
-    palette.addItem({ command, category: 'File Operations' });
+    if (palette) {
+      palette.addItem({ command, category: 'File Operations' });
+    }
   }
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3417,6 +3417,7 @@ __metadata:
     "@jupyterlab/filebrowser": ^4.2.5
     "@jupyterlab/services": ^7.2.5
     "@jupyterlab/settingregistry": ^4.2.5
+    "@jupyterlab/translation": ^4.2.5
     "@types/json-schema": ^7.0.11
     "@types/react": ^18.0.26
     "@types/react-addons-linked-state-mixin": ^0.14.22


### PR DESCRIPTION
So the quick open widget can be open via the menu too: 

![image](https://github.com/user-attachments/assets/971d3bf8-ed9f-4bca-b1e8-7a38a99da37f)
