### PR TITLE
Ensure compatibility with both sync and async contents managers

### DIFF
--- a/jupyterlab_quickopen/handler.py
+++ b/jupyterlab_quickopen/handler.py
@@ -4,6 +4,7 @@ import time
 from fnmatch import fnmatch
 
 from jupyter_server.base.handlers import APIHandler
+from jupyter_server.utils import ensure_async
 from tornado import web
 from tornado.escape import json_encode
 
@@ -39,7 +40,7 @@ class QuickOpenHandler(APIHandler):
             any(fnmatch(entry.name, glob) for glob in excludes)
             or not self.contents_manager.should_list(entry.name)
             or (
-                await self.contents_manager.is_hidden(entry.path)
+                await ensure_async(self.contents_manager.is_hidden(entry.path))
                 and not self.contents_manager.allow_hidden
             )
         )


### PR DESCRIPTION
Following #61, I inspected the class used by the instance bounded to `self.contents_manager` by printing its type before the `should_hide(...)` function returns. This is what I got before installing Jupytext.

```
<class 'jupyter_server.services.contents.largefilemanager.AsyncLargeFileManager'>
```

After installing Jupytext, the contents manager [changed](https://jupytext.readthedocs.io/en/latest/install.html#jupytext-s-contents-manager).

```
<class 'jupytext.contentsmanager.build_jupytext_contents_manager_class.<locals>.JupytextContentsManager'>
```

After digging for a while, Jupytext does not support an async contents manager and overrides the contents manager with a subclass of LargeFileManager since [1.14.3](https://github.com/mwouts/jupytext/releases/tag/v1.14.3).

Along these lines, I came up with a change to ensure we can call both sync and async methods.