### PR TITLE
Use a relative path because a path cannot start with a drive letter

### DIFF
--- a/jupyterlab_quickopen/handler.py
+++ b/jupyterlab_quickopen/handler.py
@@ -36,11 +36,13 @@ class QuickOpenHandler(APIHandler):
         -------
         bool
         """
+        relpath = os.path.relpath(entry.path)
+
         return (
             any(fnmatch(entry.name, glob) for glob in excludes)
             or not self.contents_manager.should_list(entry.name)
             or (
-                await ensure_async(self.contents_manager.is_hidden(entry.path))
+                await ensure_async(self.contents_manager.is_hidden(relpath))
                 and not self.contents_manager.allow_hidden
             )
         )


### PR DESCRIPTION
On Windows, an absolute path to files includes a drive letter, prohibited in [L271](https://github.com/jupyter-server/jupyter_server/blob/v2.14.2/jupyter_server/services/contents/fileio.py#L271) leading to the following stack trace. We should turn them into relative paths before calling `is_hidden(...)`.

```diff
[W 2024-10-16 01:15:43.420 ServerApp] wrote error: 'D:\\Workspaces\\jpt-test\\.git is not a relative API path'
    Traceback (most recent call last):
      File "D:\Workspaces\jpt-test\.venv\Lib\site-packages\tornado\web.py", line 1790, in _execute
        result = await result
                 ^^^^^^^^^^^^
      File "D:\Workspaces\jpt-test\.venv\Lib\site-packages\jupyterlab_quickopen\handler.py", line 84, in get
        contents_by_path = await self.scan_disk(full_path, excludes)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "D:\Workspaces\jpt-test\.venv\Lib\site-packages\jupyterlab_quickopen\handler.py", line 52, in scan_disk
+       if await self.should_hide(entry, excludes):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "D:\Workspaces\jpt-test\.venv\Lib\site-packages\jupyterlab_quickopen\handler.py", line 43, in should_hide
+       await ensure_async(self.contents_manager.is_hidden(entry.path))
      File "D:\Workspaces\jpt-test\.venv\Lib\site-packages\jupyter_core\utils\__init__.py", line 198, in ensure_async
        result = await obj
                 ^^^^^^^^^
      File "D:\Workspaces\jpt-test\.venv\Lib\site-packages\jupyter_server\services\contents\filemanager.py", line 1090, in is_hidden
+       os_path = self._get_os_path(path=path)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "D:\Workspaces\jpt-test\.venv\Lib\site-packages\jupyter_server\services\contents\fileio.py", line 272, in _get_os_path
+       raise HTTPError(404, "%s is not a relative API path" % path)
    tornado.web.HTTPError: HTTP 404: Not Found (D:\Workspaces\jpt-test\.git is not a relative API path)
```